### PR TITLE
chore: add .astro/ to .gitignore

### DIFF
--- a/.astro/settings.json
+++ b/.astro/settings.json
@@ -1,5 +1,0 @@
-{
-	"_variables": {
-		"lastUpdateCheck": 1731692162842
-	}
-}

--- a/.astro/types.d.ts
+++ b/.astro/types.d.ts
@@ -1,1 +1,0 @@
-/// <reference types="astro/client" />

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
 
+# astro cache directory
+.astro/
 
 # environment variables
 .env


### PR DESCRIPTION
.astro/ is used for caching and should not be tracked by git