### PR TITLE
correct equicord url

### DIFF
--- a/src/pages/plugins/index.astro
+++ b/src/pages/plugins/index.astro
@@ -25,7 +25,7 @@ import Button from "@components/Button.astro";
       <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-12">
         <Button name="Shelter" href="https://shelter.uwu.network/plugins" description="Comes with every Legcord install" />
         <Button name="Vencord" href="https://vencord.dev/plugins#" description="Togglable in Legcord settings" />
-        <Button name="Equicord" href="https://equicord.dev/plugins#" description="Togglable in Legcord settings" />
+        <Button name="Equicord" href="https://equicord.org/plugins" description="Togglable in Legcord settings" />
       </div>
       <section class="rounded-2xl border border-white/10 bg-white/5 p-6 shadow-[0_14px_45px_rgba(0,0,0,0.35)]" aria-labelledby="plugins-tips">
         <h2 id="plugins-tips" class="text-lg font-semibold text-white mb-3">Tips for using Discord plugins with Legcord</h2>


### PR DESCRIPTION
equicord has seemingly zero trace of ever using .dev as its domain from what i can find so not sure why its like this here

didnt make an issue since this is literally a 4 character change, if i should have anyways then please chop my skull off immediently